### PR TITLE
Rename function `aquire` to `acquire`

### DIFF
--- a/src/inhibitor.vala
+++ b/src/inhibitor.vala
@@ -66,11 +66,11 @@ public class Inhibitor : Object
                     // Restore the connection when internet is available again
                     Controller.wait_for_internet_cycle();
                 }
-                aquire();
+                acquire();
             }
         });
         
-        aquire();
+        acquire();
     }
 
     public void release ()
@@ -94,9 +94,9 @@ public class Inhibitor : Object
         }
     }
 
-    public void aquire ()
+    public void acquire ()
     {
-        Debug.log (Debug.domain.ENVIRONMENT, "Inhibitor.aquire", "Acquiring inhibit lock.");
+        Debug.log (Debug.domain.ENVIRONMENT, "Inhibitor.acquire", "Acquiring inhibit lock.");
         
         try
         {
@@ -104,7 +104,7 @@ public class Inhibitor : Object
         }
         catch (Error e)
         {
-            Debug.log (Debug.domain.ERROR, "Inhibitor.aquire", e.message);
+            Debug.log (Debug.domain.ERROR, "Inhibitor.acquire", e.message);
         }
     }
 }


### PR DESCRIPTION
Addresses #53

Fixes misspelled function in [`src/inhibitor.vala`](https://github.com/ztefn/haguichi/blob/26a098a9ce8db292c3af9a9118a97357eaa386e5/src/inhibitor.vala). Renamed the function from `aquire` to `acquire`.

