### PR TITLE
Add kdesu to sudo tools

### DIFF
--- a/data/com.github.ztefn.haguichi.gschema.xml
+++ b/data/com.github.ztefn.haguichi.gschema.xml
@@ -11,7 +11,8 @@
   <enum id="com.github.ztefn.haguichi.commands.super-user">
     <value value="0" nick="auto"/>
     <value value="1" nick="pkexec"/>
-    <value value="2" nick="sudo"/>
+    <value value="2" nick="kdesu"/>
+    <value value="3" nick="sudo"/>
   </enum>
 
   <enum id="com.github.ztefn.haguichi.config.protocol">

--- a/src/command.vala
+++ b/src/command.vala
@@ -130,6 +130,7 @@ namespace Haguichi {
             if (sudo == "auto") {
                 sudo = get_available ({
                     "pkexec",
+                    "kdesu",
                     "sudo"
                 }, "");
             }


### PR DESCRIPTION
Hello there is PR simply adds kdesu (for KDE Based distributions) to the list of sudo tools.

It came to my attention since I run both an Gnome based distro (Aeon Desktop) where Haguichi always worked as expected and also on some systems Kalpa Desktop (same as Aeon but ships with KDE and hence kdesu instead of pkexec)

I tested this locally using Gnome Builder and was able to use the modified Haguichi client just fine with this.